### PR TITLE
Fix release/0.123.0 Cargo.toml merge base

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "utils/string",
     "utils/cli",
     "utils/elapsed",
+    "utils/file-lock",
     "utils/sandbox-summary",
     "utils/sleep-inhibitor",
     "utils/approval-presets",
@@ -188,6 +189,7 @@ codex-utils-cache = { path = "utils/cache" }
 codex-utils-cargo-bin = { path = "utils/cargo-bin" }
 codex-utils-cli = { path = "utils/cli" }
 codex-utils-elapsed = { path = "utils/elapsed" }
+codex-utils-file-lock = { path = "utils/file-lock" }
 codex-utils-fuzzy-match = { path = "utils/fuzzy-match" }
 codex-utils-home-dir = { path = "utils/home-dir" }
 codex-utils-image = { path = "utils/image" }
@@ -378,7 +380,7 @@ unicode-width = "0.2"
 url = "2"
 urlencoding = "2.1"
 uuid = "1"
-v8 = "=146.4.0"
+v8 = "=146.9.0"
 vt100 = "0.16.2"
 walkdir = "2.5.0"
 webbrowser = "1.0"


### PR DESCRIPTION
Quick fix for the alpha.8 release merge conflict in codex-rs/Cargo.toml.

This makes release/0.123.0 use the Termux-target Cargo workspace layout while bumping the workspace version to 0.123.0-alpha.8, which should unblock the release-watch merge against rust-v0.123.0-alpha.8.