### PR TITLE
feat(ci): Add Termux artifact smoke testing workflow

### DIFF
--- a/.github/scripts/run-termux-pacman.sh
+++ b/.github/scripts/run-termux-pacman.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Run a task script inside the Termux pacman Docker image.
+set -Eeuo pipefail
+
+image="${TERMUX_IMAGE:-termux/termux-docker-pacman}"
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+packages=(termux-exec "$@")
+package_file="$(mktemp)"
+sync_file="$(mktemp)"
+task_script="$(mktemp)"
+output_dir="$(mktemp -d)"
+
+cleanup() {
+    rm -f "${package_file:-}"
+    rm -f "${sync_file:-}"
+    rm -f "${task_script:-}"
+    rm -rf "${output_dir:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+: > "$package_file"
+if (( ${#packages[@]} > 0 )); then
+    printf '%s\n' "${packages[@]}" > "$package_file"
+fi
+chmod 0644 "$package_file"
+
+: > "$sync_file"
+if [[ -n "${TERMUX_SYNC_BACK:-}" ]]; then
+    read -ra sync_paths <<< "$TERMUX_SYNC_BACK"
+    printf '%s\n' "${sync_paths[@]}" > "$sync_file"
+fi
+chmod 0644 "$sync_file"
+
+cat > "$task_script"
+chmod 0644 "$task_script"
+chmod 0777 "$output_dir"
+
+docker run --rm -i \
+    -v "$workspace:/workspace-src:ro" \
+    -v "$output_dir:/workspace-output" \
+    -v "$package_file:/tmp/termux-packages:ro" \
+    -v "$sync_file:/tmp/termux-sync-back:ro" \
+    -v "$task_script:/tmp/termux-task.sh:ro" \
+    "$image" \
+    bash -lc '
+        set -Eeuo pipefail
+        export TERMUX_VERSION="${TERMUX_VERSION:-docker}"
+
+        pacman -Syu --noconfirm
+        if [ -s /tmp/termux-packages ]; then
+            TERMUX_PACKAGES="$(tr "\n" " " < /tmp/termux-packages)"
+            # shellcheck disable=SC2086
+            pacman -S --noconfirm --needed $TERMUX_PACKAGES
+        fi
+
+        termux_exec_preload="${PREFIX:-/data/data/com.termux/files/usr}/lib/libtermux-exec-ld-preload.so"
+        if [ -r "$termux_exec_preload" ]; then
+            export LD_PRELOAD="$termux_exec_preload"
+        fi
+
+        workdir="${PREFIX:-/data/data/com.termux/files/usr}/tmp/ci-workspace"
+        rm -rf "$workdir"
+        mkdir -p "$workdir"
+        (cd /workspace-src && tar --exclude="./.git" --exclude="./target" -cf - .) |
+            (cd "$workdir" && tar -xf -)
+        chmod -R u+rwX "$workdir"
+        cd "$workdir"
+
+        bash /tmp/termux-task.sh
+
+        if [ -s /tmp/termux-sync-back ]; then
+            while IFS= read -r path; do
+                [ -n "$path" ] || continue
+                if [ ! -e "$path" ]; then
+                    echo "Expected sync-back path was not created: $path" >&2
+                    exit 1
+                fi
+
+                mkdir -p "/workspace-output/$(dirname "$path")"
+                cp -a "$path" "/workspace-output/$path"
+            done < /tmp/termux-sync-back
+        fi
+    '
+
+if [[ -s "$sync_file" ]]; then
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        if [[ ! -e "$output_dir/$path" ]]; then
+            echo "Expected sync-back path was not created: $path" >&2
+            exit 1
+        fi
+
+        mkdir -p "$workspace/$(dirname "$path")"
+        cp -a "$output_dir/$path" "$workspace/$path"
+    done < "$sync_file"
+fi

--- a/.github/scripts/termux-download-codex-artifact.sh
+++ b/.github/scripts/termux-download-codex-artifact.sh
@@ -52,10 +52,7 @@ elif [[ -n "$artifact_url" ]]; then
     rm -f "$artifact_zip"
 else
     if [[ -z "$artifact_run_id" ]]; then
-        artifact_run_id="${GITHUB_RUN_ID:-}"
-    fi
-    if [[ -z "$artifact_run_id" ]]; then
-        echo "ARTIFACT_RUN_ID or GITHUB_RUN_ID is required when ARTIFACT_NAME is used." >&2
+        echo "ARTIFACT_RUN_ID is required when ARTIFACT_NAME is used." >&2
         exit 1
     fi
 

--- a/.github/scripts/termux-download-codex-artifact.sh
+++ b/.github/scripts/termux-download-codex-artifact.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+download_dir="${DOWNLOAD_DIR:-termux-smoke-artifact}"
+release_tag="${RELEASE_TAG:-}"
+artifact_url="${ARTIFACT_URL:-}"
+artifact_run_id="${ARTIFACT_RUN_ID:-}"
+artifact_name="${ARTIFACT_NAME:-}"
+repo="${GITHUB_REPOSITORY:-wallentx/codex-termux}"
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+
+rm -rf "$download_dir"
+mkdir -p "$download_dir"
+
+source_count=0
+[[ -n "$release_tag" ]] && ((source_count += 1))
+[[ -n "$artifact_url" ]] && ((source_count += 1))
+[[ -n "$artifact_name" ]] && ((source_count += 1))
+
+if (( source_count != 1 )); then
+    echo "Specify exactly one artifact source: RELEASE_TAG, ARTIFACT_URL, or ARTIFACT_NAME." >&2
+    exit 1
+fi
+
+if [[ -n "$release_tag" ]]; then
+    echo "Downloading Android release assets from ${repo}@${release_tag}"
+    gh release download "$release_tag" \
+        --repo "$repo" \
+        --dir "$download_dir" \
+        --pattern '*aarch64-linux-android*.tar.gz'
+elif [[ -n "$artifact_url" ]]; then
+    if [[ -z "${GH_TOKEN:-}" ]]; then
+        echo "GH_TOKEN is required to download a GitHub Actions artifact URL." >&2
+        exit 1
+    fi
+    if [[ ! "$artifact_url" =~ github\.com/([^/]+/[^/]+)/actions/runs/([0-9]+)/artifacts/([0-9]+) ]]; then
+        echo "Unsupported artifact URL: $artifact_url" >&2
+        exit 1
+    fi
+
+    artifact_repo="${BASH_REMATCH[1]}"
+    artifact_id="${BASH_REMATCH[3]}"
+    artifact_zip="${download_dir}/artifact-${artifact_id}.zip"
+    echo "Downloading Actions artifact ${artifact_id} from ${artifact_repo}"
+    curl -fsSL \
+        -H "Authorization: Bearer ${GH_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -o "$artifact_zip" \
+        "https://api.github.com/repos/${artifact_repo}/actions/artifacts/${artifact_id}/zip"
+    unzip -q "$artifact_zip" -d "$download_dir"
+    rm -f "$artifact_zip"
+else
+    if [[ -z "$artifact_run_id" ]]; then
+        artifact_run_id="${GITHUB_RUN_ID:-}"
+    fi
+    if [[ -z "$artifact_run_id" ]]; then
+        echo "ARTIFACT_RUN_ID or GITHUB_RUN_ID is required when ARTIFACT_NAME is used." >&2
+        exit 1
+    fi
+
+    echo "Downloading Actions artifact ${artifact_name} from run ${artifact_run_id}"
+    gh run download "$artifact_run_id" \
+        --repo "$repo" \
+        --name "$artifact_name" \
+        --dir "$download_dir"
+fi
+
+archive="$(
+    find "$download_dir" -type f -name 'codex-aarch64-linux-android.tar.gz' -print -quit
+)"
+if [[ -z "$archive" ]]; then
+    archive="$(
+        find "$download_dir" -type f -name 'codex-package-aarch64-linux-android.tar.gz' -print -quit
+    )"
+fi
+if [[ -z "$archive" ]]; then
+    archive="$(
+        find "$download_dir" -type f -name '*aarch64-linux-android*.tar.gz' -print -quit
+    )"
+fi
+if [[ -z "$archive" ]]; then
+    echo "Could not find an aarch64-linux-android .tar.gz artifact in ${download_dir}." >&2
+    find "$download_dir" -maxdepth 4 -type f -print >&2
+    exit 1
+fi
+
+case "$archive" in
+    "$workspace"/*)
+        archive_output="${archive#"$workspace"/}"
+        ;;
+    *)
+        archive_output="$archive"
+        ;;
+esac
+
+echo "Selected smoke-test archive: ${archive_output}"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "archive_path=${archive_output}" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/termux-smoke-codex-artifact.sh
+++ b/.github/scripts/termux-smoke-codex-artifact.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+archive="${1:?Usage: termux-smoke-codex-artifact.sh <artifact.tar.gz>}"
+if [[ ! -f "$archive" ]]; then
+    echo "Artifact archive not found: $archive" >&2
+    exit 1
+fi
+
+export CODEX_SMOKE_ARCHIVE="$archive"
+
+bash .github/scripts/run-termux-pacman.sh ca-certificates libc++ tar zstd <<'TERMUX_SCRIPT'
+set -Eeuo pipefail
+
+archive="${CODEX_SMOKE_ARCHIVE:?CODEX_SMOKE_ARCHIVE is required}"
+if [[ ! -f "$archive" ]]; then
+    echo "Artifact archive not found inside Termux workspace: $archive" >&2
+    exit 1
+fi
+
+rm -rf codex-smoke
+mkdir -p codex-smoke
+tar -xzf "$archive" -C codex-smoke
+find codex-smoke -maxdepth 3 -type f -print
+
+codex=""
+for candidate in \
+    codex-smoke/codex \
+    codex-smoke/bin/codex \
+    codex-smoke/codex-aarch64-linux-android
+do
+    if [[ -x "$candidate" ]]; then
+        codex="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$codex" ]]; then
+    echo "Could not find executable codex in $archive." >&2
+    exit 1
+fi
+
+export CODEX_HOME="$PWD/codex-home"
+export RUST_BACKTRACE=1
+mkdir -p "$CODEX_HOME"
+
+"$codex" --version
+"$codex" --help | tee codex-help.txt
+grep -Eiq 'codex|usage' codex-help.txt
+"$codex" exec --help | tee codex-exec-help.txt
+grep -Eiq 'exec|usage' codex-exec-help.txt
+TERMUX_SCRIPT

--- a/.github/scripts/termux-smoke-codex-artifact.sh
+++ b/.github/scripts/termux-smoke-codex-artifact.sh
@@ -46,7 +46,9 @@ mkdir -p "$CODEX_HOME"
 
 "$codex" --version
 "$codex" --help | tee codex-help.txt
-grep -Eiq 'codex|usage' codex-help.txt
+grep -Eiq 'codex' codex-help.txt
+grep -Eiq 'usage' codex-help.txt
 "$codex" exec --help | tee codex-exec-help.txt
-grep -Eiq 'exec|usage' codex-exec-help.txt
+grep -Eiq 'exec' codex-exec-help.txt
+grep -Eiq 'usage' codex-exec-help.txt
 TERMUX_SCRIPT

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -990,7 +990,7 @@ jobs:
 
   termux-artifact-smoke:
     name: Termux artifact smoke
-    if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/') }}
+    if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: build
     permissions:
       actions: read

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -988,6 +988,22 @@ jobs:
             fi
           fi
 
+  termux-artifact-smoke:
+    name: Termux artifact smoke
+    if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/') }}
+    needs: build
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/termux-artifact-smoke.yml
+    with:
+      artifact_name: ${{ format('termux-android-pr-{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
+      artifact_run_id: ${{ github.run_id }}
+      pr_number: ${{ github.event.pull_request.number }}
+      approve_and_merge: true
+    secrets: inherit
+
   shell-tool-mcp:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'openai'
     name: shell-tool-mcp

--- a/.github/workflows/termux-artifact-smoke.yml
+++ b/.github/workflows/termux-artifact-smoke.yml
@@ -1,0 +1,98 @@
+name: termux-artifact-smoke
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: Name of the Actions artifact to download from artifact_run_id.
+        required: false
+        type: string
+        default: ""
+      artifact_run_id:
+        description: Workflow run id containing artifact_name. Defaults to the caller run id.
+        required: false
+        type: string
+        default: ""
+      pr_number:
+        description: Pull request number to approve and merge after a successful smoke test.
+        required: false
+        type: string
+        default: ""
+      approve_and_merge:
+        description: Approve and enable automerge for pr_number after a successful smoke test.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      UNEMPLOYABOT_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag containing codex-aarch64-linux-android.tar.gz.
+        required: false
+        type: string
+        default: ""
+      artifact_url:
+        description: GitHub Actions artifact URL from a rust-release run summary.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  smoke:
+    name: Smoke Codex in Termux
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download Codex Android artifact
+        id: artifact
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact_name || '' }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id || github.run_id }}
+          ARTIFACT_URL: ${{ inputs.artifact_url || '' }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || '' }}
+        run: bash .github/scripts/termux-download-codex-artifact.sh
+
+      - name: Smoke test in Termux
+        run: bash .github/scripts/termux-smoke-codex-artifact.sh "${{ steps.artifact.outputs.archive_path }}"
+
+      - name: Approve and enable PR automerge
+        if: ${{ inputs.approve_and_merge && inputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.UNEMPLOYABOT_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "UNEMPLOYABOT_TOKEN is required when approve_and_merge is true." >&2
+            exit 1
+          fi
+
+          gh pr review "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --approve \
+            --body "Termux smoke test passed on aarch64-linux-android."
+
+          gh pr merge "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --auto \
+            --delete-branch

--- a/.github/workflows/termux-artifact-smoke.yml
+++ b/.github/workflows/termux-artifact-smoke.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: ""
       artifact_run_id:
-        description: Workflow run id containing artifact_name. Defaults to the caller run id.
+        description: Workflow run id containing artifact_name. Required when artifact_name is set.
         required: false
         type: string
         default: ""
@@ -51,8 +51,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       actions: read
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     defaults:
       run:
         shell: bash
@@ -64,7 +64,7 @@ jobs:
         id: artifact
         env:
           ARTIFACT_NAME: ${{ inputs.artifact_name || '' }}
-          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id || github.run_id }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id || '' }}
           ARTIFACT_URL: ${{ inputs.artifact_url || '' }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag || '' }}
@@ -73,18 +73,40 @@ jobs:
       - name: Smoke test in Termux
         run: bash .github/scripts/termux-smoke-codex-artifact.sh "${{ steps.artifact.outputs.archive_path }}"
 
+  approve-and-merge:
+    name: Approve and enable PR automerge
+    needs: smoke
+    if: ${{ inputs.approve_and_merge && inputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check unemployabot token
+        id: token
+        env:
+          GH_TOKEN: ${{ secrets.UNEMPLOYABOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "UNEMPLOYABOT_TOKEN is unavailable; skipping automerge."
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Approve and enable PR automerge
-        if: ${{ inputs.approve_and_merge && inputs.pr_number != '' }}
+        if: ${{ steps.token.outputs.has_token == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.UNEMPLOYABOT_TOKEN }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
-
-          if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "UNEMPLOYABOT_TOKEN is required when approve_and_merge is true." >&2
-            exit 1
-          fi
 
           gh pr review "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
This pull request introduces a new automated workflow to smoke test Codex Android artifacts in a Termux environment as part of the release process. The workflow is triggered on pull requests targeting release branches and can also be run manually. It ensures that Android artifacts are downloaded, extracted, and basic functionality is verified inside a Termux Docker container. Upon a successful smoke test, the workflow can optionally approve and enable automerge for the associated pull request.

The most important changes are:

**New Termux Smoke Test Workflow:**

* Added `.github/workflows/termux-artifact-smoke.yml`, which defines a reusable workflow to download, extract, and smoke test Codex Android artifacts in a Termux environment on ARM hardware. It supports both workflow calls (for PRs) and manual dispatch (for releases), and can approve and merge PRs automatically if configured.

* Updated `.github/workflows/rust-release.yml` to invoke the new smoke test workflow as a required job for pull requests targeting release branches, passing artifact and PR information as inputs.

**Supporting Scripts for Artifact Handling and Testing:**

* Added `.github/scripts/termux-download-codex-artifact.sh` to robustly download the appropriate Android artifact from a release, artifact URL, or workflow run, and output its path for further testing.

* Added `.github/scripts/termux-smoke-codex-artifact.sh` to extract the artifact in Termux, locate the Codex executable, and verify its basic functionality with `--version`, `--help`, and `exec --help` commands.

* Added `.github/scripts/run-termux-pacman.sh` to provide a flexible, reusable entrypoint for running arbitrary scripts inside the Termux pacman Docker image, handling package installation, workspace setup, and optional file synchronization.