### PR TITLE
ci(android): Remove hardcoded NDK version for rusty_v8 builds

### DIFF
--- a/.github/scripts/rusty_v8_android_release.py
+++ b/.github/scripts/rusty_v8_android_release.py
@@ -26,7 +26,6 @@ ANDROID_GN_PYDEPS_FILES = [
 
 ANDROID_EXTRA_GN_ARGS = [
     'android_ndk_root="//third_party/android_ndk"',
-    'android_ndk_version="r26c"',
 ]
 
 


### PR DESCRIPTION
fix v8
