### PR TITLE
fix(release): keep conflicted checkpoints focused

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -990,7 +990,7 @@ jobs:
 
   termux-artifact-smoke:
     name: Termux artifact smoke
-    if: ${{ always() && github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/') && needs.build.result == 'success' }}
+    if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release/') }}
     needs: build
     permissions:
       actions: read

--- a/scripts/termux-create-checkpoint-pr.sh
+++ b/scripts/termux-create-checkpoint-pr.sh
@@ -218,11 +218,16 @@ if ! git merge --no-ff --no-edit "${source_sha}"; then
     conflict_summary="$(
       printf '%s\n' "${remaining_conflicts[@]}" | awk '{ print "- `" $0 "`" }'
     )"
-    echo "Automatic checkpoint merge failed; creating a manual-resolution PR instead." >&2
-    if git rev-parse -q --verify MERGE_HEAD >/dev/null; then
-      git merge --abort
-    fi
-    git checkout -B "${checkpoint_branch}" "${source_sha}"
+    echo "Automatic checkpoint merge needs manual resolution; keeping destination versions for conflicted paths." >&2
+    for remaining_conflict in "${remaining_conflicts[@]}"; do
+      if git cat-file -e "HEAD:${remaining_conflict}" 2>/dev/null; then
+        git checkout --ours -- "${remaining_conflict}"
+        git add "${remaining_conflict}"
+      else
+        git rm -f --ignore-unmatch "${remaining_conflict}"
+      fi
+    done
+    git commit --no-edit
   fi
 fi
 
@@ -287,7 +292,9 @@ body_path="${RUNNER_TEMP}/termux-checkpoint-pr.md"
     echo
     echo "## Merge conflicts"
     echo
-    echo "GitHub Actions could not create the checkpoint merge commit automatically, so this PR was created from the source branch state for manual conflict resolution."
+    echo "GitHub Actions kept the destination branch versions of the conflicted paths so the PR remains a focused, mergeable checkpoint instead of exposing the entire source branch as a replacement tree."
+    echo
+    echo "Review these paths and manually carry over any source-side changes that the destination still needs. Auto-merge is disabled until that review is complete."
     echo
     echo "Conflicted paths from the failed merge attempt:"
     if [[ -n "${conflict_summary}" ]]; then

--- a/scripts/test-termux-create-checkpoint-pr.sh
+++ b/scripts/test-termux-create-checkpoint-pr.sh
@@ -114,7 +114,8 @@ mkdir -p codex-rs/cli/src scripts src
 printf 'target code\n' > codex-rs/cli/src/main.rs
 printf 'target-helper\n' > scripts/termux-configure-git.sh
 printf 'target\n' > src/app.txt
-git add codex-rs/cli/src/main.rs scripts/termux-configure-git.sh src/app.txt
+printf 'shared\n' > src/conflict.txt
+git add codex-rs/cli/src/main.rs scripts/termux-configure-git.sh src/app.txt src/conflict.txt
 git commit -m "target baseline" >/dev/null
 git branch -M wallentx/termux-target
 git remote add origin "${origin}"
@@ -128,9 +129,16 @@ printf '{"termux_tag":"rust-v1.0.0-termux"}\n' > .github/termux-release.json
 printf 'tested release code\n' > codex-rs/cli/src/main.rs
 printf 'release-helper\n' > scripts/termux-download-release-artifact.sh
 printf 'release\n' > src/app.txt
-git add .github/termux-release.json codex-rs/cli/src/main.rs scripts/termux-download-release-artifact.sh src/app.txt
+printf 'release conflict\n' > src/conflict.txt
+git add .github/termux-release.json codex-rs/cli/src/main.rs scripts/termux-download-release-artifact.sh src/app.txt src/conflict.txt
 git commit -m "release branch state" >/dev/null
 git push origin release/1.0.0 >/dev/null
+
+git checkout wallentx/termux-target >/dev/null
+printf 'target conflict\n' > src/conflict.txt
+git add src/conflict.txt
+git commit -m "target branch follow-up" >/dev/null
+git push origin wallentx/termux-target >/dev/null
 
 PATH="${bin_dir}:${PATH}" \
 GITHUB_REPOSITORY="wallentx/codex-termux" \
@@ -150,14 +158,22 @@ git fetch origin checkpoint/wallentx_termux-target_from_release_1.0.0_$(git rev-
 checkpoint_ref="origin/checkpoint/wallentx_termux-target_from_release_1.0.0_$(git rev-parse --short=12 origin/release/1.0.0)"
 
 assert_ref_file_equals "${checkpoint_ref}" src/app.txt "release"
+assert_ref_file_equals "${checkpoint_ref}" src/conflict.txt "target conflict"
 assert_ref_file_equals "${checkpoint_ref}" codex-rs/cli/src/main.rs "tested release code"
 assert_ref_file_equals "${checkpoint_ref}" scripts/termux-configure-git.sh "target-helper"
 assert_ref_lacks_file "${checkpoint_ref}" scripts/termux-download-release-artifact.sh
 assert_ref_lacks_file "${checkpoint_ref}" .github/termux-release.json
+
+if ! git merge-base --is-ancestor origin/wallentx/termux-target "${checkpoint_ref}"; then
+  fail "checkpoint did not retain the destination branch as an ancestor"
+fi
+if ! git merge-base --is-ancestor origin/release/1.0.0 "${checkpoint_ref}"; then
+  fail "checkpoint did not retain the source branch as an ancestor"
+fi
 
 if [[ "$(cat "${github_output}")" != "pr_url=https://github.com/wallentx/codex-termux/pull/2" ]]; then
   cat "${github_output}" >&2
   fail "checkpoint PR URL was not written to GITHUB_OUTPUT"
 fi
 
-echo "ok - checkpoint carries tested code while restoring release-only automation paths"
+echo "ok - checkpoint carries tested code and keeps conflicted paths on the destination baseline"


### PR DESCRIPTION
$## Summary\n\n- keep manual-conflict checkpoint branches based on a merge of the destination patch stack instead of replacing it with the full release tree\n- preserve destination versions for unresolved paths and disable auto-merge until they are reviewed\n- add a divergent-branch regression fixture proving both source and destination remain ancestors\n- let the Termux artifact smoke job use normal `needs: build` success gating and the pull request base ref directly\n\n## Validation\n\n- `bash -n scripts/termux-create-checkpoint-pr.sh scripts/test-termux-create-checkpoint-pr.sh`\n- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bash scripts/test-termux-create-checkpoint-pr.sh`\n- `git diff --check`\n- `actionlint -shellcheck= .github/workflows/rust-release.yml`\n\nNo local Cargo or Rust build was run on Termux.