### PR TITLE
fix(release): persist code mode host packaging

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -594,7 +594,7 @@ jobs:
             export CARGO_BUILD_JOBS=4
             export CARGO_PROFILE_RELEASE_LTO=thin
             export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=8
-            cargo build --target ${{ matrix.target }} --release --bin codex
+            cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-code-mode-host
             exit 0
           fi
 
@@ -613,7 +613,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for binary in codex codex-responses-api-proxy; do
+          for binary in codex codex-code-mode-host codex-responses-api-proxy; do
             binary_path="target/${{ matrix.target }}/release/${binary}"
             if [[ -f "${binary_path}" ]]; then
               termux-elf-cleaner --api-level 24 "${binary_path}"
@@ -731,6 +731,7 @@ jobs:
             # For Android, we want the binary to be named just 'codex' in the archive.
             if [[ "${{ matrix.target }}" == "aarch64-linux-android" ]]; then
               cp target/${{ matrix.target }}/release/codex "$dest/codex"
+              cp target/${{ matrix.target }}/release/codex-code-mode-host "$dest/codex-code-mode-host"
             else
               cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
             fi
@@ -798,7 +799,16 @@ jobs:
             if [[ "${{ matrix.target }}" == "aarch64-linux-android" && "${base}" == "codex" ]]; then
               archive_name="codex-${{ matrix.target }}"
             fi
-            tar -C "$dest" -czf "$dest/${archive_name}.tar.gz" "$base"
+            if [[ "${{ matrix.target }}" == "aarch64-linux-android" && "${base}" == "codex" ]]; then
+              code_mode_host="codex-code-mode-host"
+              if [[ ! -x "$dest/$code_mode_host" ]]; then
+                echo "missing executable $dest/$code_mode_host" >&2
+                exit 1
+              fi
+              tar -C "$dest" -czf "$dest/${archive_name}.tar.gz" "$base" "$code_mode_host"
+            else
+              tar -C "$dest" -czf "$dest/${archive_name}.tar.gz" "$base"
+            fi
 
             # Create zip archive for Windows binaries
             # Must run from inside the dest dir so 7z won't

--- a/.github/workflows/termux-artifact-smoke.yml
+++ b/.github/workflows/termux-artifact-smoke.yml
@@ -138,6 +138,22 @@ jobs:
           exit 1
         fi
 
+        code_mode_host=""
+        for candidate in \
+          codex-smoke/codex-code-mode-host \
+          codex-smoke/bin/codex-code-mode-host
+        do
+          if [[ -x "$candidate" ]]; then
+            code_mode_host="$candidate"
+            break
+          fi
+        done
+
+        if [[ -z "$code_mode_host" ]]; then
+          echo "Could not find executable codex-code-mode-host in $archive." >&2
+          exit 1
+        fi
+
         export CODEX_HOME="$PWD/codex-home"
         export RUST_BACKTRACE=1
         mkdir -p "$CODEX_HOME"
@@ -149,3 +165,5 @@ jobs:
         "$codex" exec --help | tee codex-exec-help.txt
         grep -Eiq 'exec' codex-exec-help.txt
         grep -Eiq 'usage' codex-exec-help.txt
+        "$code_mode_host" --help | tee codex-code-mode-host-help.txt
+        grep -Eiq 'usage' codex-code-mode-host-help.txt


### PR DESCRIPTION
$## Summary\n\n- build `codex-code-mode-host` alongside `codex` for Android\n- normalize and stage both executables\n- require both binaries in the main Termux tarball\n- make the real-device smoke workflow require and execute the host\n\nThis carries the exact packaging and smoke delta already proven by the published `rust-v0.146.1-termux` artifact back into the `dev` release-automation source of truth, preventing the next release seed from dropping it. The updater-side two-binary change is retained in `wallentx/termux-target` through merged checkpoint #352.\n\n## Validation\n\n- `git diff --check`\n- `actionlint -shellcheck= .github/workflows/rust-release.yml .github/workflows/termux-artifact-smoke.yml`\n- successful real-device artifact smoke: Actions run 31052660150\n\nNo local Cargo or Rust build was run on Termux.