### PR TITLE
fix(release): keep upstream code shape authoritative

### DIFF
--- a/scripts/termux-create-release-pr.sh
+++ b/scripts/termux-create-release-pr.sh
@@ -119,10 +119,16 @@ restore_merge_authoritative_paths() {
   local -a release_restore_paths=()
 
   for path in "${TERMUX_RELEASE_CODE_PATHS[@]}"; do
-    if git cat-file -e "HEAD:${path}" 2>/dev/null; then
-      patch_restore_paths+=("${path}")
+    if termux_path_in_list "${path}" "${TERMUX_RELEASE_PATCH_AUTHORITATIVE_CODE_PATHS[@]}"; then
+      if git cat-file -e "HEAD:${path}" 2>/dev/null; then
+        patch_restore_paths+=("${path}")
+      elif git ls-files --error-unmatch -- "${path}" >/dev/null 2>&1; then
+        patch_remove_paths+=("${path}")
+      fi
+    elif git cat-file -e "${release_ref}:${path}" 2>/dev/null; then
+      release_restore_paths+=("${path}")
     elif git ls-files --error-unmatch -- "${path}" >/dev/null 2>&1; then
-      patch_remove_paths+=("${path}")
+      release_remove_paths+=("${path}")
     fi
   done
 

--- a/scripts/termux-release-paths.sh
+++ b/scripts/termux-release-paths.sh
@@ -41,6 +41,14 @@ readonly -a TERMUX_RELEASE_CODE_PATHS=(
   codex-rs/tui/src/updates.rs
 )
 
+# This file is implemented entirely by the downstream patch branch and can
+# contain checkpointed improvements that are newer than the seeded patch.
+# Other release code paths mix Termux changes into upstream-owned files, so
+# their post-merge versions must come from the newly patched release branch.
+readonly -a TERMUX_RELEASE_PATCH_AUTHORITATIVE_CODE_PATHS=(
+  codex-rs/tui/src/termux_update.rs
+)
+
 # These upstream-owned files have repeatedly retained stale checkpoint-side
 # content when a new release branch was merged into the release work branch.
 readonly -a TERMUX_RELEASE_UPSTREAM_AUTHORITATIVE_PATHS=(

--- a/scripts/test-termux-create-release-pr.sh
+++ b/scripts/test-termux-create-release-pr.sh
@@ -191,7 +191,8 @@ perl -0pi -e 's/version = "1\.0\.0"/version = "1.0.0-alpha.target"/' codex-rs/Ca
 printf 'compat\n' > termux/compat.txt
 printf 'termux\n' > src/shared.txt
 printf 'termux release code with target drift\n' > codex-rs/cli/src/main.rs
-git add codex-rs/Cargo.toml codex-rs/cli/src/main.rs termux/compat.txt src/shared.txt
+printf 'termux updater with target drift\n' > codex-rs/tui/src/termux_update.rs
+git add codex-rs/Cargo.toml codex-rs/cli/src/main.rs codex-rs/tui/src/termux_update.rs termux/compat.txt src/shared.txt
 git commit -m "termux compatibility changes" >/dev/null
 git push origin wallentx/termux-target >/dev/null
 
@@ -219,12 +220,13 @@ assert_ref_has_file origin/release/1.0.0 scripts/termux-download-release-artifac
 
 assert_ref_is_ancestor origin/release/1.0.0 origin/release-train/1.0.0
 assert_ref_file_equals origin/release-train/1.0.0 src/shared.txt "termux"
-assert_ref_file_equals origin/release-train/1.0.0 codex-rs/cli/src/main.rs "termux release code with target drift"
+assert_ref_file_equals origin/release-train/1.0.0 codex-rs/cli/src/main.rs "termux release code"
+assert_ref_file_equals origin/release-train/1.0.0 codex-rs/tui/src/termux_update.rs "termux updater with target drift"
 assert_ref_file_equals origin/release-train/1.0.0 codex-rs/Cargo.toml "[workspace.package]
 version = \"1.0.0\""
 assert_ref_has_file origin/release-train/1.0.0 src/upstream-after-tag.txt
 assert_ref_has_file origin/release-train/1.0.0 termux/compat.txt
-assert_ref_lacks_file origin/release-train/1.0.0 codex-rs/tui/src/update_versions.rs
+assert_ref_file_equals origin/release-train/1.0.0 codex-rs/tui/src/update_versions.rs "fixture"
 assert_ref_lacks_file origin/release-train/1.0.0 .github/scripts/build-codex-package-archive.sh
 assert_ref_has_file origin/release-train/1.0.0 .github/termux-release.json
 assert_ref_has_file origin/release-train/1.0.0 scripts/termux-download-release-artifact.sh
@@ -235,7 +237,7 @@ if [[ "$(cat "${github_output}")" != "pr_url=https://github.com/wallentx/codex-t
   fail "release PR URL was not written to GITHUB_OUTPUT"
 fi
 
-echo "ok - release PR head merges the release base and preserves Termux target changes"
+echo "ok - release PR head keeps patched release code and downstream-owned Termux updates"
 
 origin_update="${tmp_dir}/origin-update.git"
 work_update="${tmp_dir}/work-update"
@@ -296,7 +298,8 @@ perl -0pi -e 's/base = "1"/base = "1"\ntarget-only = "1"/' codex-rs/Cargo.toml
 printf 'termux workflow\n' > .github/workflows/rust-release.yml
 printf 'compat\n' > termux/compat.txt
 printf 'termux release code with target drift\n' > codex-rs/cli/src/main.rs
-git add .github/workflows/rust-release.yml codex-rs/Cargo.toml codex-rs/cli/src/main.rs termux/compat.txt
+printf 'termux updater with target drift\n' > codex-rs/tui/src/termux_update.rs
+git add .github/workflows/rust-release.yml codex-rs/Cargo.toml codex-rs/cli/src/main.rs codex-rs/tui/src/termux_update.rs termux/compat.txt
 git commit -m "termux compatibility changes" >/dev/null
 git push origin wallentx/termux-target >/dev/null
 
@@ -336,7 +339,8 @@ assert_ref_lacks_file origin/release/1.0.0 stale-release-branch.txt
 
 assert_ref_is_ancestor origin/release/1.0.0 origin/release-train/1.0.0
 assert_ref_file_equals origin/release-train/1.0.0 src/shared.txt "new-release"
-assert_ref_file_equals origin/release-train/1.0.0 codex-rs/cli/src/main.rs "termux release code with target drift"
+assert_ref_file_equals origin/release-train/1.0.0 codex-rs/cli/src/main.rs "termux release code"
+assert_ref_file_equals origin/release-train/1.0.0 codex-rs/tui/src/termux_update.rs "termux updater with target drift"
 assert_ref_file_equals origin/release-train/1.0.0 codex-rs/Cargo.toml "[workspace.package]
 version = \"1.0.0-alpha.2\"
 


### PR DESCRIPTION
$## Summary\n\n- keep release-patched CLI and TUI integration files authoritative when merging the long-lived Termux patch branch into a new upstream release\n- keep only the downstream-owned `termux_update.rs` authoritative from `wallentx/termux-target`, preserving checkpointed updater improvements such as `codex-code-mode-host`\n- extend the release generator fixture with deliberately stale target-side CLI and TUI files\n\nThis prevents the source mismatch that caused PR #355 run 31146879805 to fail with missing `inline_visualization`, `named_session_lookup`, state, and update-prompt symbols.\n\n## Validation\n\n- `bash -n scripts/termux-create-release-pr.sh scripts/termux-release-paths.sh scripts/test-termux-create-release-pr.sh`\n- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bash scripts/test-termux-create-release-pr.sh`\n- `git diff --check`\n\nNo local Cargo or Rust build was run on Termux.