### PR TITLE
fix(checkpoint): auto-merge fallback PRs

### DIFF
--- a/scripts/termux-create-checkpoint-pr.sh
+++ b/scripts/termux-create-checkpoint-pr.sh
@@ -99,12 +99,6 @@ resolve_source_version_conflicts() {
 
 enable_checkpoint_automerge() {
   local pr_url="$1"
-  local manual_resolution_required="${2:-false}"
-
-  if [[ "${manual_resolution_required}" == "true" ]]; then
-    echo "Skipping checkpoint auto-merge for ${pr_url}; manual conflict resolution is required."
-    return 0
-  fi
 
   local pr_info
   pr_info="$(
@@ -145,7 +139,7 @@ existing_pr="$(
     --repo "${GITHUB_REPOSITORY}" \
     --head "${checkpoint_branch}" \
     --state all \
-    --json body,number,state,mergedAt,url \
+    --json number,state,mergedAt,url \
     --jq '[.[] | select(.state == "OPEN" or .mergedAt != null)] | .[0] // empty'
 )"
 if [[ -n "${existing_pr}" ]]; then
@@ -153,12 +147,7 @@ if [[ -n "${existing_pr}" ]]; then
   existing_state="$(jq -r '.state' <<< "${existing_pr}")"
   echo "Checkpoint PR already exists for ${checkpoint_branch}: ${existing_url} (${existing_state})."
   if [[ "${existing_state}" == "OPEN" ]]; then
-    existing_body="$(jq -r '.body // ""' <<< "${existing_pr}")"
-    if [[ "${existing_body}" == *"## Merge conflicts"* ]]; then
-      enable_checkpoint_automerge "${existing_url}" true
-    else
-      enable_checkpoint_automerge "${existing_url}" false
-    fi
+    enable_checkpoint_automerge "${existing_url}"
   fi
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "pr_url=${existing_url}" >> "${GITHUB_OUTPUT}"
@@ -294,7 +283,7 @@ body_path="${RUNNER_TEMP}/termux-checkpoint-pr.md"
     echo
     echo "GitHub Actions kept the destination branch versions of the conflicted paths so the PR remains a focused, mergeable checkpoint instead of exposing the entire source branch as a replacement tree."
     echo
-    echo "Review these paths and manually carry over any source-side changes that the destination still needs. Auto-merge is disabled until that review is complete."
+    echo "Destination versions of these paths are retained in the checkpoint. Any source-side changes that are still needed can be carried forward separately."
     echo
     echo "Conflicted paths from the failed merge attempt:"
     if [[ -n "${conflict_summary}" ]]; then
@@ -319,7 +308,7 @@ gh pr edit "${pr_url}" --repo "${GITHUB_REPOSITORY}" --add-reviewer "${REVIEWER}
 gh label create checkpoint --repo "${GITHUB_REPOSITORY}" --color c5def5 --description "Checkpoint merge" --force
 gh label create termux-release --repo "${GITHUB_REPOSITORY}" --color 0e8a16 --description "Termux release automation" --force
 gh pr edit "${pr_url}" --repo "${GITHUB_REPOSITORY}" --add-label "checkpoint" --add-label "termux-release"
-enable_checkpoint_automerge "${pr_url}" "${merge_conflicted}"
+enable_checkpoint_automerge "${pr_url}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "pr_url=${pr_url}" >> "${GITHUB_OUTPUT}"

--- a/scripts/test-termux-create-checkpoint-pr.sh
+++ b/scripts/test-termux-create-checkpoint-pr.sh
@@ -52,6 +52,7 @@ origin="${tmp_dir}/origin.git"
 work="${tmp_dir}/work"
 runner_temp="${tmp_dir}/runner"
 github_output="${tmp_dir}/github-output"
+merge_log="${tmp_dir}/merge-log"
 
 mkdir -p "${bin_dir}" "${runner_temp}"
 
@@ -66,6 +67,7 @@ case "${1:-} ${2:-}" in
     printf '{"headRefOid":"checkpoint-head-sha","state":"OPEN","url":"%s"}\n' "${3:-}"
     ;;
   "pr merge")
+    printf '%s\n' "$*" >> "${TERMUX_TEST_MERGE_LOG:?}"
     [[ "${4:-}" == "--repo" ]] || {
       echo "expected --repo as fourth pr merge arg: $*" >&2
       exit 1
@@ -147,6 +149,7 @@ SOURCE_BRANCH="release/1.0.0" \
 REVIEWER="wallentx" \
 RUNNER_TEMP="${runner_temp}" \
 GITHUB_OUTPUT="${github_output}" \
+TERMUX_TEST_MERGE_LOG="${merge_log}" \
 GH_TOKEN="test-token" \
 bash "${script}" > "${tmp_dir}/stdout" 2> "${tmp_dir}/stderr" || {
   cat "${tmp_dir}/stdout" >&2
@@ -176,4 +179,9 @@ if [[ "$(cat "${github_output}")" != "pr_url=https://github.com/wallentx/codex-t
   fail "checkpoint PR URL was not written to GITHUB_OUTPUT"
 fi
 
-echo "ok - checkpoint carries tested code and keeps conflicted paths on the destination baseline"
+if [[ "$(wc -l < "${merge_log}")" -ne 1 ]]; then
+  cat "${merge_log}" >&2
+  fail "checkpoint PR auto-merge was not enabled after fallback conflict resolution"
+fi
+
+echo "ok - checkpoint carries tested code, keeps conflicted paths on the destination baseline, and enables auto-merge"


### PR DESCRIPTION
$## Summary\n\n- enable merge-commit auto-merge after checkpoint conflict fallback keeps destination versions\n- retry auto-merge for an existing open checkpoint PR regardless of its conflict disclosure\n- retain the conflicted-path list in the PR body\n- verify the fallback integration path invokes `gh pr merge --auto --merge`\n\n## Validation\n\n- `git diff --check`\n- `bash -n scripts/termux-create-checkpoint-pr.sh scripts/test-termux-create-checkpoint-pr.sh`\n- `bash scripts/test-termux-create-checkpoint-pr.sh`